### PR TITLE
Use request and response interview history schema to gather previous …

### DIFF
--- a/lib/hedge_fund_interview/beams/begin_interview.ex
+++ b/lib/hedge_fund_interview/beams/begin_interview.ex
@@ -1,5 +1,5 @@
 defmodule HedgeFundInterview.Beams.BeginInterview do
-  alias HedgeFundInterview.Prisms.SendResponseSignal
+  alias HedgeFundInterview.Prisms.RequestInterviewHistory
   alias HedgeFundInterview.Prisms.RegisterAgentSignal
 
   use Lux.Beam,
@@ -11,7 +11,7 @@ defmodule HedgeFundInterview.Beams.BeginInterview do
   def steps do
     sequence do
       step(:register_agent, RegisterAgentSignal, [:input])
-      step(:send_response, SendResponseSignal, [:input])
+      step(:request_interview_history, RequestInterviewHistory, [:input])
     end
   end
 end

--- a/lib/hedge_fund_interview/beams/interview_history_workflow.ex
+++ b/lib/hedge_fund_interview/beams/interview_history_workflow.ex
@@ -1,0 +1,25 @@
+defmodule HedgeFundInterview.Beams.InterviewHistoryWorkflow do
+  alias HedgeFundInterview.Schemas.InterviewHistoryResponseSchema
+  alias HedgeFundInterview.Prisms.AnswerInterviewQuestion
+  alias HedgeFundInterview.Prisms.GetLatestInterviewMessage
+  alias HedgeFundInterview.Prisms.SendResponseSignal
+  alias HedgeFundInterview.Prisms.StoreInterviewHistory
+  alias HedgeFundInterview.Prisms.StoreOutgoingMessage
+
+  use Lux.Beam,
+    name: "Interview History Workflow",
+    description: "A workflow for processing interview history responses and continuing the interview",
+    input_schema: InterviewHistoryResponseSchema,
+    generate_execution_log: true
+
+  @impl true
+  def steps do
+    sequence do
+      step(:store_history, StoreInterviewHistory, [:input])
+      step(:get_last_message, GetLatestInterviewMessage, [:input])
+      step(:answer, AnswerInterviewQuestion, [:steps, :get_last_message, :result])
+      step(:store_outgoing, StoreOutgoingMessage, [:steps, :answer, :result])
+      step(:send_response, SendResponseSignal, [:steps, :answer, :result])
+    end
+  end
+end

--- a/lib/hedge_fund_interview/interview_memory.ex
+++ b/lib/hedge_fund_interview/interview_memory.ex
@@ -19,8 +19,7 @@ defmodule HedgeFundInterview.InterviewMemory do
     timestamp = :os.system_time(:millisecond)
     entries =
       messages
-      |> Enum.with_index()
-      |> Enum.map(fn {msg, index} ->
+      |> Enum.with_index(fn msg, index ->
         # Add microsecond offsets to ensure unique timestamps
         # Using this offset so system time does not clash with the UTC timestamp
         # when inserting new messages afterwards

--- a/lib/hedge_fund_interview/interview_memory.ex
+++ b/lib/hedge_fund_interview/interview_memory.ex
@@ -15,6 +15,22 @@ defmodule HedgeFundInterview.InterviewMemory do
     :ok
   end
 
+  def store_messages(messages) when is_list(messages) do
+    timestamp = :os.system_time(:millisecond)
+    entries =
+      messages
+      |> Enum.with_index()
+      |> Enum.map(fn {msg, index} ->
+        # Add microsecond offsets to ensure unique timestamps
+        # Using this offset so system time does not clash with the UTC timestamp
+        # when inserting new messages afterwards
+        {timestamp + index, msg}
+      end)
+
+    :ets.insert(@table_name, entries)
+    :ok
+  end
+
   def get_last_message do
     case :ets.last(@table_name) do
       :"$end_of_table" -> nil

--- a/lib/hedge_fund_interview/prisms/answer_interview_question.ex
+++ b/lib/hedge_fund_interview/prisms/answer_interview_question.ex
@@ -6,13 +6,12 @@ defmodule HedgeFundInterview.Prisms.AnswerInterviewQuestion do
 
   @system_prompt File.read!("prompt.txt")
 
-  def handler(input, _ctx) do
-    question = input.payload["message"]
+  def handler(%{payload: payload}, ctx) do
+    handler(payload["message"], ctx)
+  end
 
-    case call_llm(question) do
-      {:ok, response} -> {:ok, response}
-      {:error, error} -> {:error, error}
-    end
+  def handler(question, _ctx) when is_binary(question) do
+    call_llm(question)
   end
 
   defp call_llm(input) do

--- a/lib/hedge_fund_interview/prisms/request_interview_history.ex
+++ b/lib/hedge_fund_interview/prisms/request_interview_history.ex
@@ -1,24 +1,22 @@
-defmodule HedgeFundInterview.Prisms.SendResponseSignal do
+defmodule HedgeFundInterview.Prisms.RequestInterviewHistory do
   use Lux.Prism
 
+  alias HedgeFundInterview.Schemas.InterviewHistoryRequestSchema
   alias HedgeFundInterview.Prisms.Utils
 
-  @interview_message_schema_id "c5f8b7e1-1b2a-5e2a-9f2a-1b2a5e2a9f2a"
-
-  def handler(answer, _ctx) do
-    response_signal = %{
+  def handler(_input, _ctx) do
+    signal = %{
       id: Lux.UUID.generate(),
       payload: %{
-        message: answer,
         job_opening_id: System.get_env("JOB_OPENING_ID")
       },
       sender: System.get_env("ANS_HANDLE"),
       receiver: "spectra_ceo",
       timestamp: DateTime.utc_now() |> DateTime.to_iso8601(),
       metadata: %{},
-      signal_schema_id: @interview_message_schema_id
+      signal_schema_id: InterviewHistoryRequestSchema.signal_schema_id()
     }
 
-    Utils.send_signal(response_signal)
+    Utils.send_signal(signal)
   end
 end

--- a/lib/hedge_fund_interview/prisms/store_interview_history.ex
+++ b/lib/hedge_fund_interview/prisms/store_interview_history.ex
@@ -1,0 +1,20 @@
+defmodule HedgeFundInterview.Prisms.StoreInterviewHistory do
+  use Lux.Prism
+  alias HedgeFundInterview.InterviewMemory
+
+  def handler(input, _ctx) do
+    messages = input.payload["interview_history"]
+
+    messages =
+      Enum.map(messages, fn m ->
+        %{
+          sender: m["sender"],
+          message: m["message"]
+        }
+      end)
+
+    InterviewMemory.store_messages(messages)
+
+    {:ok, messages}
+  end
+end

--- a/lib/hedge_fund_interview/signal_schemas/interview_history_request_schema.ex
+++ b/lib/hedge_fund_interview/signal_schemas/interview_history_request_schema.ex
@@ -1,0 +1,25 @@
+defmodule HedgeFundInterview.Schemas.InterviewHistoryRequestSchema do
+  @moduledoc """
+  The Lux schema to request the interview history of the agent.
+  """
+
+  @id "87d96f41-0414-475f-9240-ce67b90d390e"
+
+  use Lux.SignalSchema,
+    name: "interview_history_request",
+    schema: %{
+      type: "object",
+      properties: %{
+        job_opening_id: %{type: "string"}
+      },
+      required: ["job_opening_id"]
+    },
+    description: "Represents the agent asking for its interview history",
+    version: "1.0.0",
+    tags: ["hedge_fund"],
+    compatibility: "full",
+    status: "active",
+    format: "json"
+
+  def signal_schema_id, do: @id
+end

--- a/lib/hedge_fund_interview/signal_schemas/interview_history_response_schema.ex
+++ b/lib/hedge_fund_interview/signal_schemas/interview_history_response_schema.ex
@@ -1,0 +1,41 @@
+defmodule HedgeFundInterview.Schemas.InterviewHistoryResponseSchema do
+  @moduledoc """
+  The Lux schema that sends the interview history of the current application of the agent.
+  """
+
+  @id "1d7e0e59-9dc6-4f28-a992-f8579b0d0d0d"
+
+  use Lux.SignalSchema,
+    name: "interview_history_response",
+    schema: %{
+      type: "object",
+      properties: %{
+        interview_history: %{
+          type: "array",
+          items: %{
+            type: "object",
+            properties: %{
+              message: %{type: "string"},
+              sender: %{type: "string"},
+              job_application_id: %{type: "string"},
+              timestamp: %{
+                type: "string",
+                format: "date-time"
+              }
+            },
+            required: ["message", "sender", "job_application_id", "timestamp"]
+          }
+        },
+        job_opening_id: %{type: "string"}
+      },
+      required: ["interview_history", "job_opening_id"]
+    },
+    description: "Represents the agent sending its interview history",
+    version: "1.0.0",
+    tags: ["hedge_fund"],
+    compatibility: "full",
+    status: "active",
+    format: "json"
+
+  def signal_schema_id, do: @id
+end

--- a/lib/hedge_fund_interview_web/live/interview_banner_component.ex
+++ b/lib/hedge_fund_interview_web/live/interview_banner_component.ex
@@ -39,7 +39,7 @@ defmodule HedgeFundInterviewWeb.InterviewBannerComponent do
   defp banner_message(:in_progress), do: "Interview in progress... You can return to Syntax to watch it live!"
   defp banner_message(:shortlisted), do: "Amazing news! You've been shortlisted! We will contact you if we decide to move forward with your application."
   defp banner_message(:rejected), do: "Unfortunately, you've been rejected, but don't get discouraged, you can improve your agent and apply again."
-  defp banner_message(:starting_error), do: "There was an error starting the interview. Please try again."
+  defp banner_message(:starting_error), do: "There was an error starting the interview. Please make sure your config is set up correctly and try again."
   defp banner_message(:error), do: "An error occurred during the interview. Please try again."
   defp banner_message(:paused), do: "You're out of messages. Please go to the syntax UI and buy more, once you do that your agent will automatically resume your interview."
   defp banner_message(_), do: ""

--- a/lib/hedge_fund_interview_web/live/interview_button_component.ex
+++ b/lib/hedge_fund_interview_web/live/interview_button_component.ex
@@ -31,10 +31,11 @@ defmodule HedgeFundInterviewWeb.InterviewButtonComponent do
 
   @impl true
   def handle_event("begin_interview", _params, socket) do
-    case Runner.run(BeginInterview.beam(), @start_interview_message) do
-      {:ok, _beam_result, _beam_acc} ->
+    with {:ok, beam_result, _beam_acc} <- Runner.run(BeginInterview.beam(), @start_interview_message),
+         %Req.Response{status: 200} <- beam_result do
         Phoenix.PubSub.broadcast(HedgeFundInterview.PubSub, "interview_status", {:interview_started})
-        {:noreply, socket}
+      {:noreply, socket}
+    else
       _ ->
         Phoenix.PubSub.broadcast(HedgeFundInterview.PubSub, "interview_status", {:interview_start_error})
         {:noreply, socket}

--- a/lib/hedge_fund_interview_web/live/interview_button_component.ex
+++ b/lib/hedge_fund_interview_web/live/interview_button_component.ex
@@ -5,14 +5,6 @@ defmodule HedgeFundInterviewWeb.InterviewButtonComponent do
 
   @topic "interview_status"
 
-  @start_interview_message """
-    Hi, I'm #{System.get_env("ANS_HANDLE")}. I appreciate the opportunity to discuss how my background can contribute to your hedge fund. My expertise lies at the intersection of blockchain protocols, quantitative finance, and software engineering. Over the past few years, I've focused on building algorithmic trading systems that leverage machine learning and advanced statistical models to capture inefficiencies in both centralized and decentralized crypto markets.
-
-    In my recent work, I've explored L2 scaling solutions and sidechains to address throughput constraints for high-frequency trading, while simultaneously researching on-chain liquidity protocols—like Uniswap v3 and Curve—to design automated market-making strategies that mitigate impermanent loss. I'm also comfortable applying time-series analysis, factor models, and option pricing frameworks to crypto assets, ensuring robust risk management in volatile environments.
-
-    I'm excited to dive into the details of my projects and discuss how my skill set aligns with your firm's trading and DeFi initiatives.
-  """
-
   @impl true
   def render(assigns) do
     ~H"""
@@ -31,7 +23,7 @@ defmodule HedgeFundInterviewWeb.InterviewButtonComponent do
 
   @impl true
   def handle_event("begin_interview", _params, socket) do
-    with {:ok, beam_result, _beam_acc} <- Runner.run(BeginInterview.beam(), @start_interview_message),
+    with {:ok, beam_result, _beam_acc} <- Runner.run(BeginInterview.beam(), %{}),
          %Req.Response{status: 200} <- beam_result do
         Phoenix.PubSub.broadcast(HedgeFundInterview.PubSub, "interview_status", {:interview_started})
       {:noreply, socket}


### PR DESCRIPTION
With these changes, the local agent will be able to request its interview massages history so if it is stopped mid-interview, it can be re-run and resume the interview.

Upon receiving the interview history, the agent will automatically answer the last question by the interviewer.

Removed the initial interview message as now, during begin interview, the agent will respond to the initial welcome message that is expected from the interviewer.