### PR TITLE
Add agent_framework field to register signal

### DIFF
--- a/lib/hedge_fund_interview/prisms/register_agent_signal.ex
+++ b/lib/hedge_fund_interview/prisms/register_agent_signal.ex
@@ -11,7 +11,8 @@ defmodule HedgeFundInterview.Prisms.RegisterAgentSignal do
     register_agent_signal = %{
       id: Lux.UUID.generate(),
       payload: %{
-        agent_address: agent_address
+        agent_address: agent_address,
+        agent_framework: "Lux"
       },
       sender: System.get_env("ANS_HANDLE"),
       receiver: "spectra_ceo.ethAgent",

--- a/lib/hedge_fund_interview/prisms/register_agent_signal.ex
+++ b/lib/hedge_fund_interview/prisms/register_agent_signal.ex
@@ -15,6 +15,7 @@ defmodule HedgeFundInterview.Prisms.RegisterAgentSignal do
         agent_framework: "Lux"
       },
       sender: System.get_env("ANS_HANDLE"),
+      topic: nil,
       receiver: "spectra_ceo.ethAgent",
       timestamp: DateTime.utc_now() |> DateTime.to_iso8601(),
       metadata: %{},

--- a/lib/hedge_fund_interview/prisms/request_interview_history.ex
+++ b/lib/hedge_fund_interview/prisms/request_interview_history.ex
@@ -11,6 +11,7 @@ defmodule HedgeFundInterview.Prisms.RequestInterviewHistory do
         job_opening_id: System.get_env("JOB_OPENING_ID")
       },
       sender: System.get_env("ANS_HANDLE"),
+      topic: nil,
       receiver: "spectra_ceo.ethAgent",
       timestamp: DateTime.utc_now() |> DateTime.to_iso8601(),
       metadata: %{},

--- a/lib/hedge_fund_interview/prisms/send_message_count_request_signal.ex
+++ b/lib/hedge_fund_interview/prisms/send_message_count_request_signal.ex
@@ -11,6 +11,7 @@ defmodule HedgeFundInterview.Prisms.SendMessageCountRequestSignal do
       payload: %{},
       sender: System.get_env("ANS_HANDLE"),
       receiver: "spectra_ceo.ethAgent",
+      topic: nil,
       timestamp: DateTime.utc_now() |> DateTime.to_iso8601(),
       metadata: %{},
       signal_schema_id: @message_count_request_schema_id

--- a/lib/hedge_fund_interview/prisms/send_response_signal.ex
+++ b/lib/hedge_fund_interview/prisms/send_response_signal.ex
@@ -14,6 +14,7 @@ defmodule HedgeFundInterview.Prisms.SendResponseSignal do
       },
       sender: System.get_env("ANS_HANDLE"),
       receiver: "spectra_ceo.ethAgent",
+      topic: nil,
       timestamp: DateTime.utc_now() |> DateTime.to_iso8601(),
       metadata: %{},
       signal_schema_id: @interview_message_schema_id


### PR DESCRIPTION
Adding `agent_framework` to the register signal now that it is supported by the Syntax application. This will serve the purpose to identify agents build with this starter repo as built with the Lux framework.